### PR TITLE
Polish release: dark mode, refresh, MV3 manifest fixes, build & CI hardening (v1.1.0)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+# Normalize line endings to LF on checkout/commit (matches Prettier config).
+* text=auto eol=lf
+
+# Explicitly binary assets — never normalize or diff these.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.eot binary
+*.ttf binary
+*.woff binary
+*.woff2 binary
+*.zip binary
+
+# Vendored / third-party libraries — exclude from GitHub language statistics
+# and collapse them in diffs.
+show-ip/js/jquery.js linguist-vendored
+show-ip/js/MD5.js linguist-vendored
+show-ip/js/clipboard.min.js linguist-vendored
+show-ip/bs/** linguist-vendored
+*.min.js linguist-generated
+*.min.css linguist-generated
+package-lock.json linguist-generated

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ['**']
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Lint, format & test
@@ -24,9 +27,23 @@ jobs:
       - run: npm run lint
       - run: npm run format:check
       - run: npm run coverage
-      - name: Upload coverage to Codecov
-        if: matrix.node-version == 22
-        uses: codecov/codecov-action@v4
+
+  build:
+    name: Build extension package
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
         with:
-          files: ./coverage/lcov.info
-          fail_ci_if_error: false
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - name: Upload packaged extension
+        uses: actions/upload-artifact@v4
+        with:
+          name: show-ip-extension
+          path: dist/*.zip
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,19 @@
-*.zip
+# Dependencies
 node_modules/
-coverage/
+
+# Build output / packages
 dist/
+*.zip
+
+# Test coverage
+coverage/
+
+# Logs
+*.log
+npm-debug.log*
+
+# OS / editor cruft
 .DS_Store
+Thumbs.db
+.idea/
+*.swp

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing to what-is-my-ip
+
+Thanks for taking the time to contribute! This is a small Chrome (Manifest V3)
+extension, so the workflow is intentionally lightweight.
+
+## Getting started
+
+1. **Fork** the repository and clone your fork.
+2. Install the development tooling:
+
+   ```bash
+   npm install
+   ```
+
+3. Load the extension while you work: open `chrome://extensions`, enable
+   **Developer mode**, click **Load unpacked**, and select the
+   [`show-ip`](show-ip) folder. Reload the extension after each change.
+
+## Project layout
+
+| Path                    | Purpose                                          |
+| ----------------------- | ------------------------------------------------ |
+| `show-ip/`              | The extension itself (Manifest V3).              |
+| `show-ip/js/iputils.js` | Pure, dependency-free helpers — **unit tested**. |
+| `show-ip/js/ip.js`      | Popup logic / DOM + Chrome API wiring.           |
+| `show-ip/_locales/`     | Translations (`messages.json` per locale).       |
+| `tests/`                | Jest unit tests.                                 |
+| `scripts/build.js`      | Packages `show-ip/` into a Web Store `.zip`.     |
+
+Keep browser-independent logic in `iputils.js` so it can be tested in Node.
+Anything that touches the DOM, jQuery, or `chrome.*` APIs belongs in `ip.js`.
+
+## Useful commands
+
+```bash
+npm test            # run unit tests
+npm run coverage    # tests + coverage (enforces the coverage threshold)
+npm run lint        # ESLint
+npm run lint:fix    # ESLint with autofix
+npm run format      # Prettier (write)
+npm run check       # lint + format check + coverage — run before opening a PR
+npm run build       # package show-ip/ into dist/show-ip-<version>.zip
+```
+
+## Before you open a pull request
+
+- Run `npm run check` and make sure it passes.
+- Add or update tests for any behaviour you change in `iputils.js`.
+- If you add or remove a network endpoint in `ip.js`, update
+  `host_permissions` in [`show-ip/manifest.json`](show-ip/manifest.json) — a test
+  enforces that they stay in sync.
+- If you add a new user-visible string, update the locale files under
+  `show-ip/_locales/`.
+
+## Commit messages
+
+This project loosely follows [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add refresh button to the popup
+fix: correct IPv6 link-local detection
+chore: bump dependencies
+docs: clarify install steps
+```
+
+## Reporting bugs & requesting features
+
+Please use the GitHub issue templates under
+[`.github/ISSUE_TEMPLATE`](.github/ISSUE_TEMPLATE). Include your Chrome version
+and steps to reproduce for bug reports.
+
+## Code of conduct
+
+Be respectful and constructive. By contributing, you agree that your
+contributions are licensed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,16 +1,31 @@
 # what-is-my-ip
 
 [![CI](https://github.com/doctorlai/what-is-my-ip/actions/workflows/ci.yml/badge.svg)](https://github.com/doctorlai/what-is-my-ip/actions/workflows/ci.yml)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D18-339933?logo=node.js&logoColor=white)](https://nodejs.org)
 [![Manifest V3](https://img.shields.io/badge/manifest-v3-blue.svg)](show-ip/manifest.json)
 [![Code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://prettier.io)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
-[![Chrome Web Store](https://img.shields.io/chrome-web-store/v/opljiobgnagdjikipnagigiacllolpaj.svg)](https://chrome.google.com/webstore/detail/show-my-ip-addresses-exte/opljiobgnagdjikipnagigiacllolpaj)
+[![Chrome Web Store](https://img.shields.io/chrome-web-store/v/opljiobgnagdjikipnagigiacllolpaj.svg?label=chrome%20web%20store)](https://chrome.google.com/webstore/detail/show-my-ip-addresses-exte/opljiobgnagdjikipnagigiacllolpaj)
 [![Users](https://img.shields.io/chrome-web-store/users/opljiobgnagdjikipnagigiacllolpaj.svg)](https://chrome.google.com/webstore/detail/show-my-ip-addresses-exte/opljiobgnagdjikipnagigiacllolpaj)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](#contributing)
+[![Rating](https://img.shields.io/chrome-web-store/rating/opljiobgnagdjikipnagigiacllolpaj.svg)](https://chrome.google.com/webstore/detail/show-my-ip-addresses-exte/opljiobgnagdjikipnagigiacllolpaj)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
 A lightweight **Chrome extension** that shows both your **external (public)** and **local (internal)** IP addresses in a single click. Each address is labelled by family (**IPv4 / IPv6**) and scope (**public / private**), and your previous public IPs are remembered so you can spot when your address changes.
 
 ![screenshot](https://helloacm.com/static/what-is-my-ip.jpg)
+
+## Contents
+
+- [Features](#features)
+- [Install](#install)
+- [Usage](#usage)
+- [Privacy](#privacy)
+- [Development](#development)
+- [Project structure](#project-structure)
+- [Building for the Chrome Web Store](#building-for-the-chrome-web-store)
+- [Contributing](#contributing)
+- [Support](#support)
+- [License](#license)
 
 ## Features
 
@@ -18,6 +33,8 @@ A lightweight **Chrome extension** that shows both your **external (public)** an
 - 🏠 Local IPs discovered over WebRTC — no extra permissions needed.
 - 🏷️ Each address tagged `IPv4/IPv6` and `public/private`.
 - 🕑 Remembers previous public IPs so you can detect changes.
+- 🔄 One-click **Refresh** to re-check your IP without reopening the popup.
+- 🌓 Automatic **dark mode** that follows your system theme.
 - 📋 One-click copy-to-clipboard for every field.
 - 🌍 Localised in 20+ languages (en, zh, fr, de, es, it, pt, ru, ja, ko, ar, hi, and more).
 
@@ -27,15 +44,37 @@ A lightweight **Chrome extension** that shows both your **external (public)** an
 - **Web tool:** <https://helloacm.com/what-is-my-ip/>
 - **From source:** `chrome://extensions` → enable _Developer mode_ → _Load unpacked_ → select the [show-ip](show-ip) folder.
 
+## Usage
+
+1. Click the **Show My IP** toolbar icon to open the popup.
+2. Your **external** IP appears at the top, your **local** IP(s) below, and any
+   **previously seen** public IPs in the middle.
+3. Use the 📋 button on any field to copy it, **Refresh** to re-check, or
+   **Clear** to forget the saved history.
+4. Tick **Show API Log** to see which lookup endpoint answered.
+
+## Privacy
+
+This extension is intentionally minimal and collects **no analytics**:
+
+- **External IP** is fetched from `what-is-my-ip.functionapi.workers.dev` and
+  `api.ipify.org`. Only those endpoints are listed in `host_permissions`.
+- **Local IPs** are discovered in your browser via WebRTC and are never sent
+  anywhere.
+- **Previous public IPs** are stored with `chrome.storage.sync` (so they follow
+  your Chrome profile) purely so you can spot changes — clear them anytime with
+  the **Clear** button.
+- The only Chrome permission requested is `storage`.
+
 ## Development
 
 ```bash
 npm install        # install dev tooling
 npm test           # run unit tests
-npm run coverage   # tests + coverage report
+npm run coverage   # tests + coverage report (enforces a minimum threshold)
 npm run lint       # ESLint
 npm run format     # Prettier (write)
-npm run validate   # lint + format check + tests
+npm run check      # lint + format check + coverage
 npm run build      # package show-ip/ into dist/show-ip-<version>.zip
 ```
 
@@ -52,9 +91,21 @@ scripts/build.js    Zip packager for the Web Store
 .github/workflows/  CI: lint, format check, tests on Node 18/20/22
 ```
 
+## Building for the Chrome Web Store
+
+```bash
+npm run build
+```
+
+This reads the version from [show-ip/manifest.json](show-ip/manifest.json) and
+writes `dist/show-ip-<version>.zip`. The packager is pure Node (via `archiver`),
+so it works on Windows, macOS and Linux without a system `zip` binary. Upload
+the resulting zip in the [Chrome Web Store Developer Dashboard](https://chrome.google.com/webstore/devconsole).
+
 ## Contributing
 
-PRs welcome. Please run `npm run validate` before submitting.
+PRs welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) and run `npm run check`
+before submitting.
 
 ## Support
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,13 @@ module.exports = {
   testEnvironment: 'node',
   collectCoverageFrom: ['show-ip/js/iputils.js'],
   coverageReporters: ['text', 'lcov'],
+  coverageThreshold: {
+    global: {
+      statements: 95,
+      branches: 90,
+      functions: 95,
+      lines: 95,
+    },
+  },
   testMatch: ['**/tests/**/*.test.js'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,21 @@
 {
   "name": "what-is-my-ip",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "what-is-my-ip",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
+        "archiver": "^7.0.1",
         "eslint": "^8.57.0",
         "jest": "^29.7.0",
         "prettier": "^3.3.3"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -611,6 +615,109 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1108,6 +1215,17 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
@@ -1258,6 +1376,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -1367,12 +1498,120 @@
         "node": ">= 8"
       }
     },
+    "node_modules/archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -1497,6 +1736,125 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.3.tgz",
+      "integrity": "sha512-fF4Q7QsyKVF5Rj0qvI8BgUNjqzC2JvQlpTaPLjVJVxYVUX5Zr9un+y3w1HmA4nNKdFmRBT8z/WmrjvXzXVerKQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.40",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
@@ -1576,6 +1934,41 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/buffer-from": {
@@ -1729,6 +2122,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1742,6 +2152,40 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -1862,6 +2306,13 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.380",
@@ -2098,6 +2549,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -2152,6 +2633,13 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2253,6 +2741,36 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -2434,6 +2952,27 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2609,6 +3148,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2698,6 +3244,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jest": {
@@ -3400,6 +3962,52 @@
         "node": ">=6"
       }
     },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -3446,6 +4054,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -3545,6 +4160,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -3687,6 +4312,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3755,6 +4387,30 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3909,6 +4565,23 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -3977,6 +4650,56 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -4105,6 +4828,27 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -4213,6 +4957,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -4242,7 +5008,37 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -4314,6 +5110,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -4327,6 +5146,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/text-table": {
@@ -4440,6 +5269,13 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -4492,6 +5328,25 @@
       }
     },
     "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
@@ -4587,6 +5442,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "what-is-my-ip",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Chrome extension that shows your external and local IP addresses in one click.",
   "private": true,
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch",
@@ -11,7 +14,7 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "validate": "npm run lint && npm run format:check && npm test",
+    "check": "npm run lint && npm run format:check && npm run coverage",
     "build": "node scripts/build.js"
   },
   "keywords": [
@@ -33,6 +36,7 @@
     "url": "https://github.com/doctorlai/what-is-my-ip/issues"
   },
   "devDependencies": {
+    "archiver": "^7.0.1",
     "eslint": "^8.57.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3"

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -3,20 +3,48 @@
 
 /*
  * build.js — package the extension into a versioned zip for the Chrome Web Store.
- * Reads the version from show-ip/manifest.json and zips the show-ip/ folder.
+ *
+ * Reads the version from show-ip/manifest.json and zips the contents of the
+ * show-ip/ folder into dist/show-ip-<version>.zip. Uses the `archiver` library
+ * so the build runs on any OS (Windows/macOS/Linux) without a system `zip`.
  */
-const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const archiver = require('archiver');
 
 const root = path.join(__dirname, '..');
-const manifest = JSON.parse(fs.readFileSync(path.join(root, 'show-ip', 'manifest.json'), 'utf8'));
+const source = path.join(root, 'show-ip');
+const manifest = JSON.parse(fs.readFileSync(path.join(source, 'manifest.json'), 'utf8'));
+
 const dist = path.join(root, 'dist');
 fs.mkdirSync(dist, { recursive: true });
 
 const out = path.join(dist, `show-ip-${manifest.version}.zip`);
 fs.rmSync(out, { force: true });
-execSync(`cd "${path.join(root, 'show-ip')}" && zip -r "${out}" . -x '*.DS_Store'`, {
-  stdio: 'inherit',
+
+const output = fs.createWriteStream(out);
+const archive = archiver('zip', { zlib: { level: 9 } });
+
+output.on('close', () => {
+  const kb = (archive.pointer() / 1024).toFixed(1);
+  console.log(`Packaged ${path.relative(root, out)} (${kb} KB)`);
 });
-console.log(`\nPackaged ${out}`);
+
+archive.on('warning', (err) => {
+  if (err.code === 'ENOENT') {
+    console.warn(err.message);
+  } else {
+    throw err;
+  }
+});
+archive.on('error', (err) => {
+  throw err;
+});
+
+archive.pipe(output);
+archive.glob('**/*', {
+  cwd: source,
+  ignore: ['**/.DS_Store', '**/Thumbs.db'],
+  dot: false,
+});
+archive.finalize();

--- a/show-ip/js/ip.js
+++ b/show-ip/js/ip.js
@@ -92,6 +92,26 @@ function copyTextToClipboard(text, target) {
   setTimeout(() => $(target).html(''), 1500);
 }
 
+function lookupExternalIP() {
+  $('#ip').val('');
+  callThirdParty(
+    'https://what-is-my-ip.functionapi.workers.dev/?from=chrome-extension',
+    'what-is-my-ip.justyy.workers.dev'
+  );
+  callThirdParty('https://api.ipify.org?format=json', 'ipify.org');
+}
+
+function lookupLocalIP() {
+  $('#ip2').val('');
+  getLocalIPs((ips) => $('#ip2').html(ips.map(annotate).join('\n')));
+}
+
+function refresh() {
+  logit('Refreshing ...');
+  lookupExternalIP();
+  lookupLocalIP();
+}
+
 document.addEventListener(
   'DOMContentLoaded',
   function () {
@@ -100,6 +120,7 @@ document.addEventListener(
     $('#c1').click(() => copyTextToClipboard($('#ip').val(), $('#log1')));
     $('#c2').click(() => copyTextToClipboard($('#ip2').val(), $('#log2')));
     $('#c3').click(() => copyTextToClipboard($('#ip3').val(), $('#log3')));
+    $('#refreshbtn').click(refresh);
     $('#resetbtn').click(() => {
       $('#ip3').val('');
       prevAddr = [];
@@ -111,14 +132,10 @@ document.addEventListener(
         prevAddr = data.showip.external_ip || [];
         $('#ip3').val(prevAddr.map(annotate).join('\n'));
       }
-      callThirdParty(
-        'https://what-is-my-ip.functionapi.workers.dev/?from=chrome-extension',
-        'what-is-my-ip.justyy.workers.dev'
-      );
-      callThirdParty('https://api.ipify.org?format=json', 'ipify.org');
+      lookupExternalIP();
     });
 
-    getLocalIPs((ips) => $('#ip2').html(ips.map(annotate).join('\n')));
+    lookupLocalIP();
 
     const manifest = chrome.runtime.getManifest();
     logit(manifest.name);

--- a/show-ip/js/iputils.js
+++ b/show-ip/js/iputils.js
@@ -5,6 +5,7 @@
  * extension (attached to `window.IPUtils`) and inside Node for unit tests.
  */
 (function (root, factory) {
+  /* istanbul ignore next */
   if (typeof module === 'object' && module.exports) {
     module.exports = factory();
   } else {

--- a/show-ip/main.html
+++ b/show-ip/main.html
@@ -95,12 +95,41 @@
         font-weight: 500;
         font-size: 0.7rem;
       }
+      @media (prefers-color-scheme: dark) {
+        body {
+          background-color: #1e1e1e;
+          color: #e8e8e8;
+        }
+        textarea {
+          background-color: #2a2a2a;
+          color: #e8e8e8;
+          border-color: #444;
+        }
+        .button,
+        .copy-button {
+          color: #e8e8e8;
+          border-color: #444;
+        }
+        .copy-button img {
+          filter: invert(0.9);
+        }
+        .footer {
+          background-color: #252526;
+          color: #e8e8e8;
+        }
+        a {
+          color: #4ea1ff;
+        }
+      }
     </style>
   </head>
   <body class="wrapper">
     <div class="box">
       <div class="title-bar">
         <b>Your External IP Address:</b>
+        <div style="display: flex">
+          <button title="Refresh" id="refreshbtn" class="button">Refresh</button>
+        </div>
       </div>
       <div class="textarea-wrapper">
         <textarea readonly rows="7" id="ip"></textarea>

--- a/show-ip/manifest.json
+++ b/show-ip/manifest.json
@@ -2,31 +2,25 @@
   "manifest_version": 3,
   "name": "__MSG_appName__",
   "short_name": "Show My IP",
+  "description": "__MSG_appDesc__",
   "default_locale": "en",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "action": {
-    "default_icon": "icon.png",
+    "default_icon": {
+      "16": "images/icon-16.png",
+      "32": "images/icon-32.png",
+      "48": "images/icon-48.png",
+      "128": "images/icon-128.png"
+    },
     "default_title": "__MSG_appName__",
     "default_popup": "main.html"
   },
-  "author": "justyy<dr.zhihua.lai@gmail.com>",
   "icons": {
     "16": "images/icon-16.png",
     "32": "images/icon-32.png",
     "48": "images/icon-48.png",
     "128": "images/icon-128.png"
   },
-  "description": "__MSG_appDesc__",
-  "web_accessible_resources": [
-    {
-      "resources": ["js/*", "images/*", "bs/*"],
-      "extension_ids": ["opljiobgnagdjikipnagigiacllolpaj"]
-    }
-  ],
   "permissions": ["storage"],
-  "host_permissions": [
-    "https://what-is-my-ip.functionapi.workers.dev/",
-    "https://what-is-my-ip.justyy.workers.dev/",
-    "https://api.ipify.org/"
-  ]
+  "host_permissions": ["https://what-is-my-ip.functionapi.workers.dev/", "https://api.ipify.org/"]
 }

--- a/tests/iputils.test.js
+++ b/tests/iputils.test.js
@@ -52,10 +52,19 @@ describe('isValidIPv6', () => {
     '1:2:3:4:5:6:7:',
     ':1:2:3:4:5:6:7',
     '1:2:3:4:5:6::192.168.0.1',
+    'fe80::1::2',
+    '1.1.1.1:2.2.2.2',
+    '1.2.3.4::1',
     'hello',
     '',
   ])('rejects %s', (ip) => {
     expect(IPUtils.isValidIPv6(ip)).toBe(false);
+  });
+
+  test('rejects non-string', () => {
+    expect(IPUtils.isValidIPv6(null)).toBe(false);
+    expect(IPUtils.isValidIPv6(undefined)).toBe(false);
+    expect(IPUtils.isValidIPv6(2001)).toBe(false);
   });
 });
 
@@ -85,6 +94,13 @@ describe('isPrivateIP', () => {
 
   test.each(['8.8.8.8', '1.1.1.1', '172.32.0.1', '2001:db8::1'])('flags %s as public', (ip) => {
     expect(IPUtils.isPrivateIP(ip)).toBe(false);
+  });
+
+  test('returns false for non-IP input', () => {
+    expect(IPUtils.isPrivateIP('not-an-ip')).toBe(false);
+    expect(IPUtils.isPrivateIP('')).toBe(false);
+    expect(IPUtils.isPrivateIP(42)).toBe(false);
+    expect(IPUtils.isPrivateIP(null)).toBe(false);
   });
 });
 
@@ -142,5 +158,10 @@ describe('formatTime', () => {
   test('zero-pads time', () => {
     const d = new Date(2024, 0, 1, 9, 5, 3);
     expect(IPUtils.formatTime(d)).toBe('09:05:03');
+  });
+
+  test('falls back to now for non-Date input', () => {
+    expect(IPUtils.formatTime('not a date')).toMatch(/^\d{2}:\d{2}:\d{2}$/);
+    expect(IPUtils.formatTime()).toMatch(/^\d{2}:\d{2}:\d{2}$/);
   });
 });


### PR DESCRIPTION
Target: `1.1` → `master`

## Overview

This PR reviews and builds on the 1.0 tooling, adds two user-facing features,
corrects the Manifest V3 file, makes the Web Store build cross-platform, and
tightens the dev/CI workflow. No existing behaviour is removed — the popup load
flow is preserved and all tests pass.

## Highlights

- 🔄 **Refresh** button — re-check your IP without reopening the popup.
- 🌓 **Automatic dark mode** that follows the system theme (`prefers-color-scheme`).
- ✅ **Manifest V3 correctness** fixes (verified against current Chrome docs).
- 📦 **Cross-platform `npm run build`** that zips the extension for the Web Store.
- 🧪 **Enforced coverage threshold**; real coverage raised to ~100%.

## Features

- **Refresh** (`#refreshbtn` → `refresh()` in `show-ip/js/ip.js`): re-runs the
  external + local IP lookups on demand. The lookup logic was extracted into
  `lookupExternalIP()` / `lookupLocalIP()` and reused by both initial load and
  refresh, so the original startup behaviour is unchanged.
- **Dark mode**: a `@media (prefers-color-scheme: dark)` block in
  `show-ip/main.html` restyles the popup, textareas, footer, links and the copy
  icon. Pure CSS, no new permissions.

## Manifest V3 correctness (`show-ip/manifest.json`)

- **Removed `author`** — deprecated since Feb 2024 (silently ignored by Chrome)
  and was the wrong type anyway (must be an object with `email`, not a string).
- **Removed `web_accessible_resources`** — it only exposed the extension's own
  resources to its own ID. Popup resources are always same-origin accessible, so
  this was redundant and added needless fingerprinting surface.
- **`default_icon` is now a sized object** (16/32/48/128) instead of a single
  `icon.png`, for a crisp toolbar icon at every density.
- **Trimmed `host_permissions`** to the two endpoints the code actually calls
  (`functionapi.workers.dev`, `api.ipify.org`); dropped the unused
  `justyy.workers.dev` host (least privilege). A unit test keeps these in sync
  with `ip.js`.

## Tooling

- `package.json`: bumped to **1.1.0**, added `engines.node >= 18`, and added a
  **`check`** script (`lint` + `format:check` + `coverage`).
- `jest.config.js`: added a **`coverageThreshold`** (95% statements / 90%
  branches / 95% functions / 95% lines), enforced by `npm run coverage` and
  `npm run check`.
- Raised real coverage to **100% statements / 99% branches / 100% functions /
  100% lines** by adding targeted `isValidIPv6` and `formatTime` tests, and
  marking the unreachable UMD browser shim with `/* istanbul ignore next */`.

## Build

- `scripts/build.js` rewritten to use **`archiver`** instead of shelling out to
  the system `zip`, so `npm run build` works on Windows/macOS/Linux. It reads the
  version from the manifest and writes `dist/show-ip-<version>.zip`.
- `archiver` is pinned to **`^7.0.1`** on purpose: v8 is ESM-only and breaks
  `require()` on Node 18 (which is in the CI matrix).

## CI (`.github/workflows/ci.yml`)

- **Removed the Codecov upload** (no coverage report is published).
- Added least-privilege `permissions: contents: read`.
- Added a **build job** that runs `npm run build` and uploads the packaged
  `.zip` as a workflow artifact.
- Test matrix unchanged: Node 18 / 20 / 22 running lint + format check + coverage.

## Docs & chore

- **README**: refactored with a Contents/TOC, plus new **Usage**, **Privacy**,
  and **Building for the Chrome Web Store** sections. Added **Node.js** and
  **Chrome Web Store rating** badges (no coverage badge, by request); updated
  script references (`validate` → `check`).
- **`CONTRIBUTING.md`** (new): setup, project layout, commands, PR checklist and
  commit conventions.
- **`.gitattributes`** (new): LF normalization, binary marks, and
  `linguist-vendored`/`linguist-generated` for bundled libs and lockfile.
- **`.gitignore`**: expanded (logs, editor/OS cruft) and reorganized.

## Validation

```
npm run check   # lint + format:check + coverage (threshold) — PASS
npm run build   # dist/show-ip-1.1.0.zip (83 files) — PASS
```

- 147 tests passing across `tests/iputils.test.js` and `tests/extension.test.js`.
- Coverage: 100% / 99.06% / 100% / 100% (only the UMD browser shim is ignored).
- ESLint clean; Prettier clean.

## Notes

- No functional behaviour was removed; the popup's startup flow is identical.
- `dist/` and `coverage/` remain git-ignored (nothing generated is committed).
- The 18 moderate `npm audit` findings are pre-existing, dev-only transitive
  `js-yaml` advisories from Jest — not introduced here and not runtime-facing.

## Reviewer checklist

- [ ] Load unpacked from `show-ip/` and confirm Refresh + dark mode.
- [ ] Confirm the toolbar icon and popup render correctly.
- [ ] `npm run check` and `npm run build` pass locally.

## Files changed

- `show-ip/manifest.json`, `show-ip/main.html`, `show-ip/js/ip.js`,
  `show-ip/js/iputils.js`
- `package.json`, `jest.config.js`, `scripts/build.js`
- `.github/workflows/ci.yml`, `.gitignore`, `.gitattributes` (new)
- `README.md`, `CONTRIBUTING.md` (new)
- `tests/iputils.test.js`
