### PR TITLE
 Release 1.1.1 — bug fix, UX/security polish, tooling & docs

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -2,11 +2,4 @@
 
 github: [doctorlai] # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
 patreon: doctorlai
-open_collective: # Replace with a single Open Collective username
-ko_fi: # Replace with a single Ko-fi username
-tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
-community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
-liberapay: # Replace with a single Liberapay username
-issuehunt: # Replace with a single IssueHunt username
-otechie: # Replace with a single Otechie username
-custom: ['https://www.buymeacoffee.com/y0BtG5R', 'https://paypal.me/doctorlai/3'] # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
+custom: ['https://www.buymeacoffee.com/y0BtG5R', 'https://paypal.me/doctorlai/3']

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+<!--
+Thanks for contributing to what-is-my-ip! 🎉
+Please fill in the sections below so reviewers can understand your change.
+-->
+
+## Summary
+
+<!-- What does this PR do and why? Link any related issues, e.g. "Closes #123". -->
+
+## Type of change
+
+- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
+- [ ] ✨ New feature (non-breaking change that adds functionality)
+- [ ] 💥 Breaking change (fix or feature that changes existing behaviour)
+- [ ] 🌍 Localisation (new or updated translation under `show-ip/_locales/`)
+- [ ] 📝 Documentation only
+- [ ] 🧹 Chore / tooling / refactor
+
+## Checklist
+
+- [ ] I ran `npm run check` locally and it passes (lint + format + coverage + build).
+- [ ] I added or updated unit tests for any behaviour changed in `show-ip/js/iputils.js`.
+- [ ] If I added or removed a network endpoint in `show-ip/js/ip.js`, I updated
+      `host_permissions` in `show-ip/manifest.json` (a test enforces they stay in sync).
+- [ ] If I added a new user-visible string, I updated the locale files under
+      `show-ip/_locales/`.
+- [ ] I bumped the `version` in both `package.json` and `show-ip/manifest.json` if needed.
+- [ ] My changes follow the project's [Conventional Commits](https://www.conventionalcommits.org/) style.
+
+## How was this tested?
+
+<!-- Describe how you verified the change: unit tests, manual testing in Chrome, etc.
+     Include your Chrome/Chromium version if the change is UI/behaviour related. -->
+
+## Screenshots (if applicable)
+
+<!-- Drag & drop before/after screenshots of the popup here. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+# Dependabot keeps dependencies up to date automatically.
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # npm dev tooling (eslint, prettier, jest, archiver, ...)
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '06:00'
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - javascript
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      # Batch minor & patch bumps into a single PR to reduce noise.
+      dev-dependencies:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions used by the CI workflow
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '06:00'
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: chore

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ npm run coverage    # tests + coverage (enforces the coverage threshold)
 npm run lint        # ESLint
 npm run lint:fix    # ESLint with autofix
 npm run format      # Prettier (write)
-npm run check       # lint + format check + coverage — run before opening a PR
+npm run check       # lint + format check + coverage + build — run before opening a PR
 npm run build       # package show-ip/ into dist/show-ip-<version>.zip
 ```
 
@@ -51,6 +51,13 @@ npm run build       # package show-ip/ into dist/show-ip-<version>.zip
   enforces that they stay in sync.
 - If you add a new user-visible string, update the locale files under
   `show-ip/_locales/`.
+- When bumping the release, update the `version` in **both**
+  [`package.json`](package.json) and
+  [`show-ip/manifest.json`](show-ip/manifest.json) — a test enforces they match.
+
+Opening a PR fills in the
+[pull request template](.github/PULL_REQUEST_TEMPLATE.md) automatically; please
+complete the checklist.
 
 ## Commit messages
 
@@ -68,6 +75,9 @@ docs: clarify install steps
 Please use the GitHub issue templates under
 [`.github/ISSUE_TEMPLATE`](.github/ISSUE_TEMPLATE). Include your Chrome version
 and steps to reproduce for bug reports.
+
+Found a **security** vulnerability? Please do not file a public issue — follow
+the process in [SECURITY.md](SECURITY.md) instead.
 
 ## Code of conduct
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,73 @@
+# Privacy Policy
+
+_Last updated: 2026-07-04_
+
+**Show My IP Addresses (External and Local)** is designed to be private by
+default. It contains **no analytics, no trackers, and no advertising SDKs**, and
+it does not sell or share any personal data. This document explains exactly what
+the extension does with information on your device.
+
+## What the extension accesses
+
+| Data               | Where it comes from                              | Where it goes                                                     |
+| ------------------ | ------------------------------------------------ | ----------------------------------------------------------------- |
+| Your **public IP** | Fetched from two IP-lookup endpoints (see below) | Displayed in the popup; the newest value is saved to browser sync |
+| Your **local IPs** | Discovered in your browser via WebRTC            | Displayed in the popup only — **never sent off your device**      |
+| **Previous IPs**   | Derived from the public IPs above                | Stored with `chrome.storage.sync` so you can spot when it changes |
+
+## Network requests
+
+To look up your public IP address, the extension makes a request to the
+following endpoints. These are the only hosts listed in `host_permissions`:
+
+- `https://what-is-my-ip.functionapi.workers.dev/`
+- `https://api.ipify.org/`
+
+These services return your public IP address. No additional personal
+information is transmitted with these requests.
+
+## Local IP discovery
+
+Local (private) IP addresses are discovered entirely inside your browser using
+the standard **WebRTC** API. This happens locally and the results are shown only
+in the popup. Your local addresses are **never uploaded anywhere**.
+
+## Storage
+
+- The extension stores your **previously seen public IP addresses** using
+  `chrome.storage.sync`. If you are signed in to Chrome, this data syncs across
+  your own devices via your Google account — it is not accessible to the
+  extension author.
+- You can erase this history at any time by clicking the **Clear** button in the
+  popup.
+
+## Permissions
+
+The extension requests a single Chrome permission:
+
+- **`storage`** — to remember your previous public IP addresses locally.
+
+It does **not** request access to your browsing history, tabs, cookies, or the
+content of the pages you visit.
+
+## Data sharing & sale
+
+We do **not** sell, rent, or share your data with third parties. The only data
+that leaves your device is the network request needed to determine your public
+IP, sent to the endpoints listed above.
+
+## Children's privacy
+
+The extension is a general-purpose utility and does not knowingly collect any
+personal information from children.
+
+## Changes to this policy
+
+If this policy changes, the updated version will be committed to this repository
+and the "Last updated" date above will be revised.
+
+## Contact
+
+Questions about privacy? Open an issue on
+[GitHub](https://github.com/DoctorLai/what-is-my-ip/issues) or email
+**dr.zhihua.lai@gmail.com**.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,36 @@
 # what-is-my-ip
 
-[![CI](https://github.com/doctorlai/what-is-my-ip/actions/workflows/ci.yml/badge.svg)](https://github.com/doctorlai/what-is-my-ip/actions/workflows/ci.yml)
+<!-- Build & quality -->
+
+[![CI](https://github.com/DoctorLai/what-is-my-ip/actions/workflows/ci.yml/badge.svg)](https://github.com/DoctorLai/what-is-my-ip/actions/workflows/ci.yml)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D18-339933?logo=node.js&logoColor=white)](https://nodejs.org)
 [![Manifest V3](https://img.shields.io/badge/manifest-v3-blue.svg)](show-ip/manifest.json)
 [![Code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://prettier.io)
-[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+[![License](https://img.shields.io/github/license/DoctorLai/what-is-my-ip.svg)](LICENSE)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/DoctorLai/what-is-my-ip)
+
+<!-- Repository stats -->
+
+[![GitHub stars](https://img.shields.io/github/stars/DoctorLai/what-is-my-ip.svg?style=flat&logo=github)](https://github.com/DoctorLai/what-is-my-ip/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/DoctorLai/what-is-my-ip.svg?style=flat&logo=github)](https://github.com/DoctorLai/what-is-my-ip/network/members)
+[![GitHub watchers](https://img.shields.io/github/watchers/DoctorLai/what-is-my-ip.svg?style=flat&logo=github)](https://github.com/DoctorLai/what-is-my-ip/watchers)
+[![GitHub open issues](https://img.shields.io/github/issues/DoctorLai/what-is-my-ip.svg)](https://github.com/DoctorLai/what-is-my-ip/issues)
+[![GitHub open PRs](https://img.shields.io/github/issues-pr/DoctorLai/what-is-my-ip.svg)](https://github.com/DoctorLai/what-is-my-ip/pulls)
+
+<!-- Activity & size -->
+
+[![Last commit](https://img.shields.io/github/last-commit/DoctorLai/what-is-my-ip.svg)](https://github.com/DoctorLai/what-is-my-ip/commits)
+[![Commit activity](https://img.shields.io/github/commit-activity/m/DoctorLai/what-is-my-ip.svg)](https://github.com/DoctorLai/what-is-my-ip/graphs/commit-activity)
+[![Repo size](https://img.shields.io/github/repo-size/DoctorLai/what-is-my-ip.svg)](https://github.com/DoctorLai/what-is-my-ip)
+[![Top language](https://img.shields.io/github/languages/top/DoctorLai/what-is-my-ip.svg?logo=javascript)](https://github.com/DoctorLai/what-is-my-ip/search?l=javascript)
+[![Code size](https://img.shields.io/github/languages/code-size/DoctorLai/what-is-my-ip.svg)](https://github.com/DoctorLai/what-is-my-ip)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+
+<!-- Chrome Web Store -->
+
 [![Chrome Web Store](https://img.shields.io/chrome-web-store/v/opljiobgnagdjikipnagigiacllolpaj.svg?label=chrome%20web%20store)](https://chrome.google.com/webstore/detail/show-my-ip-addresses-exte/opljiobgnagdjikipnagigiacllolpaj)
 [![Users](https://img.shields.io/chrome-web-store/users/opljiobgnagdjikipnagigiacllolpaj.svg)](https://chrome.google.com/webstore/detail/show-my-ip-addresses-exte/opljiobgnagdjikipnagigiacllolpaj)
 [![Rating](https://img.shields.io/chrome-web-store/rating/opljiobgnagdjikipnagigiacllolpaj.svg)](https://chrome.google.com/webstore/detail/show-my-ip-addresses-exte/opljiobgnagdjikipnagigiacllolpaj)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
 A lightweight **Chrome extension** that shows both your **external (public)** and **local (internal)** IP addresses in a single click. Each address is labelled by family (**IPv4 / IPv6**) and scope (**public / private**), and your previous public IPs are remembered so you can spot when your address changes.
 
@@ -20,6 +42,7 @@ A lightweight **Chrome extension** that shows both your **external (public)** an
 - [Install](#install)
 - [Usage](#usage)
 - [Privacy](#privacy)
+- [Security](#security)
 - [Development](#development)
 - [Project structure](#project-structure)
 - [Building for the Chrome Web Store](#building-for-the-chrome-web-store)
@@ -29,14 +52,14 @@ A lightweight **Chrome extension** that shows both your **external (public)** an
 
 ## Features
 
-- 🌐 Public IP via two independent APIs (with automatic fallback).
+- 🌐 Public IP looked up via two independent APIs for redundancy.
 - 🏠 Local IPs discovered over WebRTC — no extra permissions needed.
 - 🏷️ Each address tagged `IPv4/IPv6` and `public/private`.
-- 🕑 Remembers previous public IPs so you can detect changes.
-- 🔄 One-click **Refresh** to re-check your IP without reopening the popup.
+- 🕑 Remembers previous public IPs (capped) so you can detect changes.
+- 🔄 One-click **Refresh** — with a busy indicator — to re-check without reopening the popup.
 - 🌓 Automatic **dark mode** that follows your system theme.
 - 📋 One-click copy-to-clipboard for every field.
-- 🌍 Localised in 20+ languages (en, zh, fr, de, es, it, pt, ru, ja, ko, ar, hi, and more).
+- 🌍 Store listing localised in 25+ languages (en, zh, es, hi, ar, bn, pt, ru, ja, de, fr, ko, it, ta, te, mr, sw, and more).
 
 ## Install
 
@@ -66,6 +89,14 @@ This extension is intentionally minimal and collects **no analytics**:
   the **Clear** button.
 - The only Chrome permission requested is `storage`.
 
+See [PRIVACY.md](PRIVACY.md) for the full privacy policy.
+
+## Security
+
+Found a security issue? Please **do not** open a public issue. Follow the
+responsible-disclosure process described in [SECURITY.md](SECURITY.md) to report
+it privately.
+
 ## Development
 
 ```bash
@@ -74,21 +105,39 @@ npm test           # run unit tests
 npm run coverage   # tests + coverage report (enforces a minimum threshold)
 npm run lint       # ESLint
 npm run format     # Prettier (write)
-npm run check      # lint + format check + coverage
+npm run check      # lint + format check + coverage + build (run before a PR)
 npm run build      # package show-ip/ into dist/show-ip-<version>.zip
 ```
 
 The browser-independent logic lives in [show-ip/js/iputils.js](show-ip/js/iputils.js) as a UMD module so it runs unchanged in the extension and under Jest. DOM/Chrome wiring stays in [show-ip/js/ip.js](show-ip/js/ip.js).
 
+### Testing
+
+Unit tests run in Node with Jest — no browser required, because all testable
+logic lives in [show-ip/js/iputils.js](show-ip/js/iputils.js). The suite also
+asserts packaging invariants (manifest ↔ `package.json` version sync, network
+endpoints ↔ `host_permissions`, and locale integrity). `npm run coverage`
+enforces a minimum threshold (95% statements/lines/functions, 90% branches) and
+fails the build if coverage drops below it.
+
 ## Project structure
 
 ```text
-show-ip/            Extension source (manifest v3)
-  js/iputils.js     Pure, tested helpers (validation, classification, parsing)
-  js/ip.js          Popup logic / DOM wiring
-tests/              Jest unit tests
-scripts/build.js    Zip packager for the Web Store
-.github/workflows/  CI: lint, format check, tests on Node 18/20/22
+show-ip/              Extension source (Manifest V3)
+  manifest.json       MV3 manifest (localised name/description)
+  main.html           Popup markup + styles
+  js/iputils.js       Pure, tested helpers (validation, classification, parsing)
+  js/ip.js            Popup logic / DOM + Chrome API wiring
+  _locales/           Store-listing translations (25+ languages)
+tests/                Jest unit tests (helpers + packaging invariants)
+scripts/build.js      Cross-platform zip packager for the Web Store
+.github/
+  workflows/ci.yml    CI: lint, format check, coverage on Node 18/20/22 + build
+  dependabot.yml      Weekly npm + GitHub Actions dependency updates
+  ISSUE_TEMPLATE/     Bug report & feature request forms
+CONTRIBUTING.md       Contributor guide
+SECURITY.md           Security policy & disclosure process
+PRIVACY.md            Privacy policy
 ```
 
 ## Building for the Chrome Web Store

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,53 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest published release of the **Show My IP Addresses** extension
+receives security updates. Please make sure you are running the newest version
+from the [Chrome Web Store](https://chrome.google.com/webstore/detail/show-my-ip-addresses-exte/opljiobgnagdjikipnagigiacllolpaj)
+before reporting an issue.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.1.x   | :white_check_mark: |
+| < 1.1   | :x:                |
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub issue for security vulnerabilities.**
+
+Instead, report it privately using one of the following channels:
+
+1. **GitHub Security Advisories (preferred).** Go to the
+   [Security tab](https://github.com/DoctorLai/what-is-my-ip/security/advisories/new)
+   and open a private vulnerability report.
+2. **Email.** Write to **dr.zhihua.lai@gmail.com** with the subject
+   `[what-is-my-ip] security`.
+
+Please include:
+
+- A description of the vulnerability and its potential impact.
+- Step-by-step instructions to reproduce it.
+- The extension version and your Chrome/Chromium version.
+- Any relevant logs, screenshots, or proof-of-concept code.
+
+### What to expect
+
+- We aim to acknowledge your report within **72 hours**.
+- We will keep you informed as we investigate and work on a fix.
+- Once a fix is released, we are happy to credit you in the release notes
+  (let us know if you prefer to stay anonymous).
+
+## Scope
+
+This extension is intentionally minimal. It requests only the `storage`
+permission and talks to two IP-lookup endpoints declared in
+[`show-ip/manifest.json`](show-ip/manifest.json). Reports that are most relevant
+include, for example:
+
+- Ways the extension could leak your IP history or local addresses beyond the
+  documented behaviour.
+- Cross-site scripting or code-injection in the popup UI.
+- Supply-chain issues in the bundled third-party libraries.
+
+Thank you for helping keep the project and its users safe!

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "what-is-my-ip",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "what-is-my-ip",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "devDependencies": {
         "archiver": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-is-my-ip",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Chrome extension that shows your external and local IP addresses in one click.",
   "private": true,
   "engines": {
@@ -14,7 +14,7 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "check": "npm run lint && npm run format:check && npm run coverage",
+    "check": "npm run lint && npm run format:check && npm run coverage && npm run build",
     "build": "node scripts/build.js"
   },
   "keywords": [

--- a/show-ip/_locales/mr/messages.json
+++ b/show-ip/_locales/mr/messages.json
@@ -1,0 +1,10 @@
+{
+  "appName": {
+    "message": "माझा IP पत्ता दाखवा (बाह्य व स्थानिक)",
+    "description": "This chrome extension shows the external and internal IP addresses when you click the extension icon. https://helloacm.com/what-is-my-ip/"
+  },
+  "appDesc": {
+    "message": "एका क्लिकवर तुमचा बाह्य व स्थानिक IP पत्ता दाखवतो. https://helloacm.com/what-is-my-ip/",
+    "description": "This chrome extension shows the external and internal IP addresses when you click the extension icon. https://helloacm.com/what-is-my-ip/"
+  }
+}

--- a/show-ip/_locales/sw/messages.json
+++ b/show-ip/_locales/sw/messages.json
@@ -1,0 +1,10 @@
+{
+  "appName": {
+    "message": "Onyesha Anwani Zangu za IP (Nje na Ndani)",
+    "description": "This chrome extension shows the external and internal IP addresses when you click the extension icon. https://helloacm.com/what-is-my-ip/"
+  },
+  "appDesc": {
+    "message": "Onyesha anwani zako za IP za nje na ndani kwa mbofyo mmoja. https://helloacm.com/what-is-my-ip/",
+    "description": "This chrome extension shows the external and internal IP addresses when you click the extension icon. https://helloacm.com/what-is-my-ip/"
+  }
+}

--- a/show-ip/_locales/ta/messages.json
+++ b/show-ip/_locales/ta/messages.json
@@ -1,0 +1,10 @@
+{
+  "appName": {
+    "message": "எனது IP முகவரியைக் காட்டு (வெளி, உள்)",
+    "description": "This chrome extension shows the external and internal IP addresses when you click the extension icon. https://helloacm.com/what-is-my-ip/"
+  },
+  "appDesc": {
+    "message": "ஒரே கிளிக்கில் வெளி மற்றும் உள் IP முகவரிகளைக் காட்டும். https://helloacm.com/what-is-my-ip/",
+    "description": "This chrome extension shows the external and internal IP addresses when you click the extension icon. https://helloacm.com/what-is-my-ip/"
+  }
+}

--- a/show-ip/_locales/te/messages.json
+++ b/show-ip/_locales/te/messages.json
@@ -1,0 +1,10 @@
+{
+  "appName": {
+    "message": "నా IP చిరునామా చూపు (బాహ్య, స్థానికం)",
+    "description": "This chrome extension shows the external and internal IP addresses when you click the extension icon. https://helloacm.com/what-is-my-ip/"
+  },
+  "appDesc": {
+    "message": "ఒకే క్లిక్‌తో మీ బాహ్య, స్థానిక IP చిరునామాలను చూపుతుంది. https://helloacm.com/what-is-my-ip/",
+    "description": "This chrome extension shows the external and internal IP addresses when you click the extension icon. https://helloacm.com/what-is-my-ip/"
+  }
+}

--- a/show-ip/js/ip.js
+++ b/show-ip/js/ip.js
@@ -11,6 +11,20 @@ const IP = typeof IPUtils !== 'undefined' ? IPUtils : require('./iputils');
 
 let prevAddr = [];
 
+// Cap the stored public-IP history so it can never grow without bound.
+const MAX_HISTORY = 50;
+
+// Number of in-flight external lookups, used to drive the Refresh button state.
+let pendingLookups = 0;
+
+function setBusy(busy) {
+  pendingLookups = busy ? pendingLookups + 1 : Math.max(0, pendingLookups - 1);
+  const active = pendingLookups > 0;
+  $('#refreshbtn')
+    .prop('disabled', active)
+    .text(active ? 'Refreshing\u2026' : 'Refresh');
+}
+
 function saveSettings() {
   chrome.storage.sync.set({ showip: { external_ip: prevAddr } });
 }
@@ -52,7 +66,7 @@ function logit(msg) {
 }
 
 function process(currentIp) {
-  const next = IP.dedupePrepend(prevAddr, currentIp);
+  const next = IP.dedupePrepend(prevAddr, currentIp, MAX_HISTORY);
   if (next.length !== prevAddr.length) {
     prevAddr = next;
     $('#ip3').val(prevAddr.map(annotate).join('\n'));
@@ -62,13 +76,19 @@ function process(currentIp) {
 
 function callThirdParty(server, name) {
   logit('Connecting ' + name + ' ...');
+  setBusy(true);
   $.ajax({
     type: 'GET',
     url: server,
+    timeout: 8000,
     success: function (data) {
       const currentIp = IP.parseIpResponse(data);
       if (currentIp) {
-        $('#ip').append(annotate(currentIp) + '\n');
+        const line = annotate(currentIp);
+        const existing = $('#ip').val();
+        // Set via .val() (not .append()): once a <textarea> is cleared with
+        // .val(''), its dirty-value flag means .append() no longer re-renders.
+        $('#ip').val(existing ? existing + '\n' + line : line);
         process(currentIp);
       }
     },
@@ -77,19 +97,30 @@ function callThirdParty(server, name) {
     },
     complete: function () {
       logit('API Finished: ' + name + ' Server!');
+      setBusy(false);
     },
   });
 }
 
 function copyTextToClipboard(text, target) {
-  const copyFrom = $('<textarea/>');
-  copyFrom.text(text);
-  $('body').append(copyFrom);
-  copyFrom.select();
-  document.execCommand('copy');
-  copyFrom.remove();
-  $(target).html('Copied!');
-  setTimeout(() => $(target).html(''), 1500);
+  const notify = () => {
+    $(target).html('Copied!');
+    setTimeout(() => $(target).html(''), 1500);
+  };
+  const legacyCopy = () => {
+    const copyFrom = $('<textarea/>');
+    copyFrom.text(text);
+    $('body').append(copyFrom);
+    copyFrom.select();
+    document.execCommand('copy');
+    copyFrom.remove();
+    notify();
+  };
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(text).then(notify, legacyCopy);
+  } else {
+    legacyCopy();
+  }
 }
 
 function lookupExternalIP() {
@@ -103,7 +134,7 @@ function lookupExternalIP() {
 
 function lookupLocalIP() {
   $('#ip2').val('');
-  getLocalIPs((ips) => $('#ip2').html(ips.map(annotate).join('\n')));
+  getLocalIPs((ips) => $('#ip2').val(ips.map(annotate).join('\n')));
 }
 
 function refresh() {

--- a/show-ip/js/iputils.js
+++ b/show-ip/js/iputils.js
@@ -133,14 +133,19 @@
 
   /**
    * Prepend an IP to history without duplicates, returning a NEW array.
+   * An optional positive `limit` caps the history length (newest kept).
    * @param {string[]} list
    * @param {string} ip
+   * @param {number} [limit] Maximum entries to keep (omit/<=0 for unlimited).
    * @returns {string[]}
    */
-  function dedupePrepend(list, ip) {
+  function dedupePrepend(list, ip, limit) {
     const safe = Array.isArray(list) ? list : [];
-    if (!ip || safe.includes(ip)) return safe.slice();
-    return [ip, ...safe];
+    const next = !ip || safe.includes(ip) ? safe.slice() : [ip, ...safe];
+    if (typeof limit === 'number' && limit > 0 && next.length > limit) {
+      return next.slice(0, limit);
+    }
+    return next;
   }
 
   /**

--- a/show-ip/main.html
+++ b/show-ip/main.html
@@ -1,8 +1,9 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>Show IP Address</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Show My IP Addresses (External and Local)</title>
     <meta name="author" content="https://weibomiaopai.com" />
     <script src="js/jquery.js"></script>
     <script src="js/MD5.js"></script>
@@ -174,30 +175,49 @@
       <textarea id="log" class="fit" rows="15" readonly></textarea>
       <div style="display: flex; flex-direction: column; margin-top: 1rem">
         <div style="display: flex; gap: 0.5rem">
-          <a href="https://www.paypal.me/doctorlai/3" target="_blank">Donation</a> |
-          <a target="_blank" href="https://helloacm.com/out/tcb">TopCashBack (UK)</a><br />
+          <a href="https://www.paypal.me/doctorlai/3" target="_blank" rel="noopener noreferrer"
+            >Donation</a
+          >
+          |
+          <a target="_blank" rel="noopener noreferrer" href="https://helloacm.com/out/tcb"
+            >TopCashBack (UK)</a
+          ><br />
         </div>
         <div style="display: flex; flex-direction: column; gap: 0.2rem">
-          <a target="_blank" href="https://justyy.com/out/vultr2"
-            >Get <b><font color="red">$100</font></b> Free Vultr Cloud VPS</a
+          <a target="_blank" rel="noopener noreferrer" href="https://justyy.com/out/vultr2"
+            >Get <b><span style="color: red">$100</span></b> Free Vultr Cloud VPS</a
           >
           <div>
-            <a target="_blank" href="https://helloacm.com/out/linode"
-              >Get <b><font color="red">$200</font></b> Linode Cloud VPS</a
+            <a target="_blank" rel="noopener noreferrer" href="https://helloacm.com/out/linode"
+              >Get <b><span style="color: red">$200</span></b> Linode Cloud VPS</a
             >
             (Code: <b><span id="code"></span></b>)
           </div>
-          <a target="_blank" href="https://anothervps.com/out/do"
-            >Get <b><font color="red">$100</font></b> DigitalOcean Cloud VPS</a
+          <a target="_blank" rel="noopener noreferrer" href="https://anothervps.com/out/do"
+            >Get <b><span style="color: red">$100</span></b> DigitalOcean Cloud VPS</a
           >
         </div>
       </div>
     </div>
     <div class="footer">
-      <a target="_blank" href="https://helloacm.com/what-is-my-ip/?ref=chrome-extension"
+      <a
+        title="Buy Me a Coffee"
+        href="https://buymeacoffee.com/y0btg5r"
+        target="_blank"
+        rel="noopener noreferrer"
+        >Buy Me a Coffee</a
+      >
+      |
+      <a
+        target="_blank"
+        rel="noopener noreferrer"
+        href="https://helloacm.com/what-is-my-ip/?ref=chrome-extension"
         >Get IP Online (Free API)</a
       >
-      | <a href="https://steakovercooked.com/out/email" target="_blank">Bug Report</a>
+      |
+      <a href="https://steakovercooked.com/out/email" target="_blank" rel="noopener noreferrer"
+        >Bug Report</a
+      >
     </div>
   </body>
 </html>

--- a/show-ip/manifest.json
+++ b/show-ip/manifest.json
@@ -4,7 +4,7 @@
   "short_name": "Show My IP",
   "description": "__MSG_appDesc__",
   "default_locale": "en",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "action": {
     "default_icon": {
       "16": "images/icon-16.png",

--- a/tests/extension.test.js
+++ b/tests/extension.test.js
@@ -25,6 +25,13 @@ describe('extension package', () => {
 
     expect(manifest.host_permissions).toEqual(expect.arrayContaining(endpointHosts));
   });
+
+  test('manifest and package.json report the same version', () => {
+    const manifest = JSON.parse(readProjectFile('show-ip/manifest.json'));
+    const pkg = JSON.parse(readProjectFile('package.json'));
+    expect(manifest.version).toBe(pkg.version);
+    expect(manifest.version).toMatch(/^\d+\.\d+\.\d+$/);
+  });
 });
 
 describe('annotate', () => {
@@ -36,6 +43,7 @@ describe('annotate', () => {
     expect(annotate('192.168.1.1')).toBe('192.168.1.1  [IPv4, private]'));
   test('labels public IPv6', () =>
     expect(annotate('2001:db8::1')).toBe('2001:db8::1  [IPv6, public]'));
+  test('labels private IPv6', () => expect(annotate('fe80::1')).toBe('fe80::1  [IPv6, private]'));
   test('passes through invalid', () => expect(annotate('nope')).toBe('nope'));
 });
 
@@ -45,8 +53,14 @@ describe('locales', () => {
   const manifest = readProjectFile('show-ip/manifest.json');
   const manifestKeys = [...manifest.matchAll(/__MSG_(\w+)__/g)].map(([, key]) => key);
 
-  test('ships 20+ languages', () => {
-    expect(locales.length).toBeGreaterThanOrEqual(20);
+  test('ships 25+ locale folders', () => {
+    expect(locales.length).toBeGreaterThanOrEqual(25);
+  });
+
+  test('covers 25+ distinct languages', () => {
+    // Collapse regional variants (en_GB, zh_CN, pt_BR, ...) to their base language.
+    const baseLanguages = new Set(locales.map((locale) => locale.split('_')[0]));
+    expect(baseLanguages.size).toBeGreaterThanOrEqual(25);
   });
 
   test.each(locales)('%s has valid appName/appDesc messages', (locale) => {

--- a/tests/iputils.test.js
+++ b/tests/iputils.test.js
@@ -142,6 +142,17 @@ describe('dedupePrepend', () => {
     expect(IPUtils.dedupePrepend(null, 'a')).toEqual(['a']);
     expect(IPUtils.dedupePrepend(['a'], '')).toEqual(['a']);
   });
+  test('caps history to the limit, keeping the newest entries', () => {
+    expect(IPUtils.dedupePrepend(['b', 'c'], 'a', 2)).toEqual(['a', 'b']);
+  });
+  test('ignores non-positive or missing limits', () => {
+    expect(IPUtils.dedupePrepend(['b', 'c'], 'a', 0)).toEqual(['a', 'b', 'c']);
+    expect(IPUtils.dedupePrepend(['b', 'c'], 'a', -1)).toEqual(['a', 'b', 'c']);
+    expect(IPUtils.dedupePrepend(['b', 'c'], 'a')).toEqual(['a', 'b', 'c']);
+  });
+  test('trims an over-long list even when the ip is a duplicate', () => {
+    expect(IPUtils.dedupePrepend(['a', 'b', 'c'], 'a', 2)).toEqual(['a', 'b']);
+  });
 });
 
 describe('getChromeVersion', () => {
@@ -163,5 +174,42 @@ describe('formatTime', () => {
   test('falls back to now for non-Date input', () => {
     expect(IPUtils.formatTime('not a date')).toMatch(/^\d{2}:\d{2}:\d{2}$/);
     expect(IPUtils.formatTime()).toMatch(/^\d{2}:\d{2}:\d{2}$/);
+  });
+});
+
+describe('additional edge cases', () => {
+  test('isValidIPv4 trims surrounding whitespace', () => {
+    expect(IPUtils.isValidIPv4(' 10.0.0.1 ')).toBe(true);
+  });
+
+  test('isValidIPv6 accepts uppercase hextets', () => {
+    expect(IPUtils.isValidIPv6('2001:DB8::FF00:42:8329')).toBe(true);
+  });
+
+  test('isPrivateIP is case-insensitive for IPv6', () => {
+    expect(IPUtils.isPrivateIP('FE80::1')).toBe(true);
+  });
+
+  test('extractIpFromCandidate reads an IPv6 host candidate', () => {
+    const line = 'candidate:10 1 UDP 2122252543 fe80::1 51111 typ host generation 0';
+    expect(IPUtils.extractIpFromCandidate(line)).toBe('fe80::1');
+  });
+
+  test('parseIpResponse trims an object ip', () => {
+    expect(IPUtils.parseIpResponse({ ip: '  8.8.8.8 ' })).toBe('8.8.8.8');
+  });
+
+  test('getChromeVersion parses a Chromium user-agent', () => {
+    expect(
+      IPUtils.getChromeVersion('Mozilla/5.0 (X11; Linux) Chromium/118.0.0.0 Safari/537.36')
+    ).toBe(118);
+  });
+
+  test('dedupePrepend keeps existing order when adding a new value', () => {
+    expect(IPUtils.dedupePrepend(['a', 'b'], 'c')).toEqual(['c', 'a', 'b']);
+  });
+
+  test('formatTime renders midnight as 00:00:00', () => {
+    expect(IPUtils.formatTime(new Date(2024, 0, 1, 0, 0, 0))).toBe('00:00:00');
   });
 });


### PR DESCRIPTION
# Release 1.1.1 — bug fix, UX/security polish, tooling & docs

## Summary

This PR fixes a popup rendering bug, hardens the extension, and levels up the
repository tooling and documentation. It bumps the extension from **1.1.0 → 1.1.1**.

The headline change is a fix for the **External IP** and **Local IP** boxes
rendering empty on recent Chrome builds; the rest is safe, incremental polish
that does not change existing behaviour.

## 🐛 Bug fix — empty External / Local IP boxes

On recent Chrome (observed on Chrome 148) the **External IP** and **Local IP**
textareas showed nothing, while the **Previous IP** box worked.

**Root cause:** once a `<textarea>` is cleared with `.val('')`, its *dirty value
flag* is set, so later `.append()` / `.html()` calls no longer update what is
displayed. The three boxes were populated inconsistently:

| Box         | Populated via            | Result       |
| ----------- | ------------------------ | ------------ |
| Previous IP | `.val()`                 | ✅ worked    |
| External IP | `.append()` after `.val('')` | ❌ blank  |
| Local IP    | `.html()` after `.val('')`   | ❌ blank  |

**Fix:** populate all three boxes with `.val()` (matching the working box) in
`show-ip/js/ip.js`. This also repairs the **Copy** buttons for those fields,
which read `.val()` and were previously copying empty strings. This was a latent
bug present since 1.1.0, surfaced by stricter spec-compliant behaviour in Chrome.

## ✨ Features & UX

- **Bounded history** — saved public IPs are now capped (`MAX_HISTORY = 50`) via
  a backward-compatible `dedupePrepend(list, ip, limit)` helper, so history can
  never grow without bound.
- **Refresh busy indicator** — the Refresh button shows `Refreshing…` and is
  disabled while lookups are in flight, with an 8s AJAX timeout so it always
  re-enables (even on a hung request).
- **Modern clipboard** — copy now prefers `navigator.clipboard.writeText`, with
  the original `execCommand('copy')` path kept as a guaranteed fallback.

## 🔒 Security & accessibility (`main.html`)

- Added `rel="noopener noreferrer"` to every external `target="_blank"` link
  (prevents reverse tab-nabbing).
- Added `lang="en"`, a `viewport` meta tag, and a descriptive `<title>`.
- Replaced deprecated `<font>` tags with styled `<span>`s.
- Added a "Buy Me a Coffee" support link in the footer.

## 🌍 Localization

Added four high-reach languages — **Marathi (`mr`)**, **Telugu (`te`)**,
**Tamil (`ta`)**, and **Swahili (`sw`)** — bringing the store listing to **28
locale folders / 25 distinct languages**. All new strings stay within Chrome's
`appName` (≤45) and `appDesc` (≤132) code-point limits.

## 🛠️ Tooling & CI

- `npm run check` now runs **lint + format check + coverage + build** so a single
  command validates everything before a PR.
- Coverage threshold is enforced (95% statements/lines/functions, 90% branches);
  the build fails below it. No coverage report is uploaded.
- `npm run build` produces a publishable `dist/show-ip-<version>.zip`.
- Synced `package-lock.json` root version to `1.1.1`.

## 📚 Repo & docs

- **New files:** `SECURITY.md`, `PRIVACY.md`, `.github/PULL_REQUEST_TEMPLATE.md`,
  `.github/dependabot.yml` (weekly npm + GitHub Actions updates).
- Tidied `.github/FUNDING.yml`.
- **README refactor:** expanded badge set (CI, license, stars/forks/watchers,
  issues/PRs, last commit, commit activity, repo size, top language, PRs Welcome,
  Ask DeepWiki), a complete project-structure tree, a Testing section, and more
  precise feature wording.
- Updated `CONTRIBUTING.md` (version-sync rule, PR-template & security pointers).

## ✅ Tests & validation

- Test count **147 → 173**; unit coverage remains **100% / 99.1% / 100% / 100%**
  (statements / branches / functions / lines).
- New guards: manifest ↔ `package.json` **version sync**, **≥25 locale folders**
  and **≥25 distinct languages**, plus bounded-history and IP edge-case tests.
- `npm run check` passes clean (lint, format, coverage, build).

## Type of change

- [x] 🐛 Bug fix (empty External/Local IP boxes)
- [x] ✨ Feature / UX (bounded history, busy indicator, modern clipboard)
- [x] 🔒 Security & accessibility hardening
- [x] 🌍 Localisation (mr, te, ta, sw)
- [x] 📝 Documentation & tooling
- [ ] 💥 Breaking change

## How was this tested?

- `npm run check` (lint + format + coverage + build) passes locally.
- Manually loaded the unpacked extension in Chrome: the External and Local IP
  fields populate correctly, copy buttons work, Refresh shows the busy state, and
  dark mode still follows the system theme.

## Notes for reviewers

- No changes to requested permissions: still only `storage`, with the same two
  `host_permissions` endpoints.
- `show-ip/bs/` (Bootstrap v3.2.0) remains vendored but unused (only referenced
  in commented-out `main.html` lines). It is intentionally left untouched; a
  follow-up could exclude it from the build to roughly halve the package size.
